### PR TITLE
Pttp 3736/move prometheus config to configmap

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,6 @@ version: 0.2
 
 env:
   parameter-store:
-    TERRAFORM_OUTPUTS: "/terraform_staff_infrastructure_monitoring/$ENV/outputs"
     THANOS_IMAGE_REPOSITORY_URL: "/codebuild/pttp-ci-ima-pipeline/thanos_image_repository_url"
     CLOUDWATCH_EXPORTER_IMAGE_REPOSITORY_URL: "/codebuild/pttp-ci-ima-pipeline/cloudwatch_exporter_image_repository_url"
 

--- a/kubernetes/infrastructure-monitoring/templates/prometheus-configmap.yaml
+++ b/kubernetes/infrastructure-monitoring/templates/prometheus-configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-configmap
+data:
+  prometheus.yml: |
+    global:
+      scrape_timeout:      60s # Set the scrape interval to every 30 seconds. Default is every 10 secs.
+      scrape_interval:     180s # Set the scrape interval to every 60 seconds. Default is every 1 minute.
+      evaluation_interval: 60s # Evaluate rules every 60 seconds. The default is every 1 minute.
+      external_labels:
+        environment: production
+
+    remote_write:
+      - url: http://{{ .Release.Name }}-thanos-receiver:10908/api/v1/receive
+
+    scrape_configs:
+      - job_name: prometheus
+        honor_labels: true
+        static_configs:
+          - targets:
+            - localhost:9090
+        metrics_path: /metrics
+
+      - job_name: cloudwatch
+        honor_labels: true
+        static_configs:
+          - targets: ['{{ .Release.Name }}-cloudwatch-exporter:5000']
+
+      - job_name: docker_images
+        scheme: https
+        static_configs:
+          - targets:
+            - raw.githubusercontent.com:443
+        metrics_path: /ministryofjustice/staff-device-docker-base-images/main/prometheus_metrics/docker_image_versions.txt
+
+      - job_name: grafana
+        honor_labels: true
+        scheme: https
+        static_configs:
+          - targets:
+            - monitoring-alerting.staff.service.justice.gov.uk:443
+        metrics_path: /metrics
+
+    

--- a/kubernetes/infrastructure-monitoring/templates/prometheus-deployment.yaml
+++ b/kubernetes/infrastructure-monitoring/templates/prometheus-deployment.yaml
@@ -32,6 +32,8 @@ spec:
         - name: alert-rules
           mountPath: "/alerts"
           readOnly: true
+        - name: configuration
+          mountPath: "/etc/prometheus"
       volumes:
       - name: prometheus-data
       - name: alert-rules
@@ -40,3 +42,9 @@ spec:
           items:
           - key: "alertRules.yml"
             path: "alertRules.yml"
+      - name: configuration
+        configMap:
+          name: prometheus-configmap
+          items:
+          - key: "prometheus.yml"
+            path: "prometheus.yml"


### PR DESCRIPTION
Prometheus config now contains a scrape job for Cloudwatch exporter. (deployed as a configmap rather than baked into the docker image).