### PR TITLE
A few tweaks to cloudwatch exporter config

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
+++ b/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
@@ -4,9 +4,51 @@
   regions: [eu-west-2]
   dimensions:
   - name: ClusterName
-    values: staff-device-{{ .Values.environment }}-dhcp-cluster
+    value: staff-device-{{ .Values.environment }}-dhcp-cluster
+  - name: ServiceName
+    value: staff-device-{{ .Values.environment }}-dhcp-standby-service
+  metrics:
+  - name: RunningTaskCount
+    statistics: [Average]
+    nilToZero: true
+    period: 300
+    length: 300
+- namespace: ECS/ContainerInsights
+  name: "ECS - Container Insights"
+  regions: [eu-west-2]
+  dimensions:
   - name: ClusterName
-    values: staff-device-{{ .Values.environment }}-dns-cluster"
+    value: staff-device-{{ .Values.environment }}-dhcp-cluster
+  - name: ServiceName
+    value: staff-device-{{ .Values.environment }}-dhcp-primary-service
+  metrics:
+  - name: RunningTaskCount
+    statistics: [Average]
+    nilToZero: true
+    period: 300
+    length: 300
+- namespace: ECS/ContainerInsights
+  name: "ECS - Container Insights"
+  regions: [eu-west-2]
+  dimensions:
+  - name: ClusterName
+    value: staff-device-{{ .Values.environment }}-dhcp-cluster
+  - name: ServiceName
+    value: staff-device-{{ .Values.environment }}-dhcp-api-service
+  metrics:
+  - name: RunningTaskCount
+    statistics: [Average]
+    nilToZero: true
+    period: 300
+    length: 300
+- namespace: ECS/ContainerInsights
+  name: "ECS - Container Insights"
+  regions: [eu-west-2]
+  dimensions:
+  - name: ClusterName
+    value: staff-device-{{ .Values.environment }}-dns-cluster
+  - name: ServiceName
+    value: staff-device-{{ .Values.environment }}-dns-service
   metrics:
   - name: RunningTaskCount
     statistics: [Average]
@@ -120,7 +162,7 @@
 - namespace: Kea-DHCP
   name: "Kea DHCP"
   regions: [eu-west-2]
-  dimensions
+  dimensions:
   - name: Server
     value: primary
   - name: Server

--- a/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics.tpl
+++ b/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics.tpl
@@ -208,25 +208,5 @@ discovery:
         statistics: [Average, Sum]
         nilToZero: true
 static:
-- namespace: AWS/ECS
-  regions: [eu-west-2]
-  name: "AWS/ECS"
-  roleArns: [{{ .Values.cloudwatchExporter.accessRoleArns }}]
-  dimensions:
-  - name: ClusterName
-    value: staff-device-{{ .Values.environment }}-dhcp-cluster
-  - name: ClusterName
-    value: staff-device-{{ .Values.environment }}-dns-cluster"
-  metrics:
-  - name: CPUUtilization
-    statistics: [Average, Minimum, Maximum]
-    nilToZero: true
-    period: 300
-    length: 300
-  - name: MemoryUtilization
-    statistics: [Average]
-    nilToZero: true
-    period: 300
-    length: 300
 {{- include "cloudwatchMetrics.production.custom" . }}
 {{ end }}

--- a/kubernetes/infrastructure-monitoring/values.yaml
+++ b/kubernetes/infrastructure-monitoring/values.yaml
@@ -8,7 +8,7 @@ thanos:
     enabled: false
 cloudwatchExporter:
   image: ""
-  assumeRoleArns: ""
+  accessRoleArns: ""
 prometheusThanosStorageBucket:
   bucketName: ""
   endpoint: "s3.eu-west-2.amazonaws.com"


### PR DESCRIPTION
- fix formatting error, missing :
- remove static config for AWS/ECS as it wasn't working. Have added a tag to the clusters in question so they can be discovered dynamically.
- specify both cluster name and service name for ECS/ContainerInsights dimensions
- correct name in values file