### PR TITLE
Added ingress host to alertmanager

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/alertmanager-service.yaml
+++ b/kubernetes/infrastructure-monitoring/templates/alertmanager-service.yaml
@@ -2,7 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-alertmanager
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
 spec:
+  type: LoadBalancer
   selector:
     app: alertmanager
   ports:

--- a/kubernetes/infrastructure-monitoring/templates/ingress-nginx.yaml
+++ b/kubernetes/infrastructure-monitoring/templates/ingress-nginx.yaml
@@ -16,3 +16,13 @@ spec:
               name: {{ .Release.Name }}-thanos-querier
               port:
                 number: 10902
+  - host: alertmanager-{{ .Release.Namespace }}.{{ .Values.hosted_zone_private }}
+    http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Release.Name }}-alertmanager
+              port:
+                number: 9093


### PR DESCRIPTION
This PR will change the alertmanager service to `type: LoadBalancer` and add an associated host to the ingress.