### PR TITLE
adds configmap-reload sideacars in Prometheus and Alertmanager pods

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/alertmanager-deployment.yaml
+++ b/kubernetes/infrastructure-monitoring/templates/alertmanager-deployment.yaml
@@ -29,9 +29,16 @@ spec:
         volumeMounts:
         - name: configuration
           mountPath: "/config"
-          readOnly: true
         - name: templates
           mountPath: "/templates"
+      - name: alertmanager-configmap-reload
+        image: {{ .Values.configmap_reload.image }}:latest
+        args:
+          - "--volume-dir=/config"
+          - "--webhook-url=http://127.0.0.1:9093/-/reload"
+        volumeMounts:
+        - name: configuration
+          mountPath: "/config"
           readOnly: true
       volumes:
       - name: configuration

--- a/kubernetes/infrastructure-monitoring/templates/prometheus-deployment.yaml
+++ b/kubernetes/infrastructure-monitoring/templates/prometheus-deployment.yaml
@@ -33,9 +33,21 @@ spec:
           mountPath: "/var/lib/prometheus"
         - name: alert-rules
           mountPath: "/alerts"
-          readOnly: true
         - name: configuration
           mountPath: "/etc/prometheus"
+      - name: prometheus-configmap-reload
+        image: {{ .Values.configmap_reload.image }}:latest
+        args:
+          - "--volume-dir=/etc/prometheus"
+          - "--volume-dir=/alerts"
+          - "--webhook-url=http://127.0.0.1:9090/-/reload"
+        volumeMounts:
+        - name: configuration
+          mountPath: "/etc/prometheus"
+          readOnly: true
+        - name: alert-rules
+          mountPath: "/alerts"
+          readOnly: true
       volumes:
       - name: prometheus-data
       - name: alert-rules

--- a/kubernetes/infrastructure-monitoring/values.yaml
+++ b/kubernetes/infrastructure-monitoring/values.yaml
@@ -2,6 +2,8 @@ environment: ""
 hosted_zone_private: ""
 hosted_zone_public: ""
 debug: false
+configmap_reload:
+  image: ""
 prometheus:
   image: ""
 thanos:

--- a/scripts/deploy_kubernetes.sh
+++ b/scripts/deploy_kubernetes.sh
@@ -77,6 +77,7 @@ upgrade_ima_chart(){
   helm upgrade --install mojo-$KUBERNETES_NAMESPACE-ima --namespace $KUBERNETES_NAMESPACE --create-namespace ./kubernetes/infrastructure-monitoring --set \
 environment=$ENV,\
 prometheus.image=$SHARED_SERVICES_ECR_BASE_URL/prometheus,\
+configmap_reload.image=jimmidyson/configmap-reload,\
 alertmanager.image=prom/alertmanager,\
 prometheusThanosStorageBucket.bucketName=$prometheus_thanos_storage_bucket_name,\
 cloudwatchExporter.image=$SHARED_SERVICES_ECR_BASE_URL/cloudwatch-exporter,\


### PR DESCRIPTION
in future this sidecar can be added to Azure exporter pods too
adds a placeholder in the Values.yaml and passing the image through the deployment script.