### PR TITLE
:stethoscope: update nac metric namespace

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
+++ b/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
@@ -325,8 +325,8 @@
     nilToZero: true
     period: 300
     length: 300
-- namespace: mojo-production-nac-requests
-  name: "mojo-production-nac-requests"
+- namespace: mojo-nac-requests
+  name: "mojo-nac-requests"
   regions: [eu-west-2]
   metrics:
   - name: Error


### PR DESCRIPTION
This PR will rename the metric namespace that cloudwatch exporter watches for.  This will allow metrics to be scraped from all accounts.