### PR TITLE
:stethoscope: Add SOP OCI URLs to Prom config

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/prometheus-configmap.yaml
+++ b/kubernetes/infrastructure-monitoring/templates/prometheus-configmap.yaml
@@ -103,6 +103,9 @@ data:
             # PSN Service URLs
             - https://intranet.noms.gsi.gov.uk/ # There is no routing via PSN so removing
             - https://www.ppud.gsi.gov.uk/ # There is no routing via PSN so removing
+            # SOP OCI
+            - https://sop.govsharedservices.gov.uk:4450/accessgate/dossologin
+            - https://sop.govsharedservices.gov.uk:4450
         relabel_configs:
           - source_labels: [__address__]
             target_label: __param_target


### PR DESCRIPTION
This PR adds the SOP OCI url to the prometheus config to monitor them for http response codes.