### PR TITLE
:wrench: Update Palo Alto GP Dashboard 

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
+++ b/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
@@ -392,8 +392,8 @@
     nilToZero: true
     period: 300
     length: 300
-- namespace: GP_VMseries
-  name: "GP_VMseries"
+- namespace: GP_GATEWAY_VMseries
+  name: "GP_GATEWAY_VMseries"
   regions: [eu-west-2]
   roleArns: [{{ .Values.cloudwatchExporter.accessRoleArns }}]
   metrics:


### PR DESCRIPTION
update to use correct cloudwatch namespace the gateways are logging to