### PR TITLE
:bug: Removed Colon From The Nacs Health Check Metric Name

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
+++ b/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics-custom.tpl
@@ -387,7 +387,7 @@
     nilToZero: true
     period: 300
     length: 300
-  - name: "Health Check: OK"
+  - name: "Health Check OK"
     statistics: [Sum]
     nilToZero: true
     period: 300


### PR DESCRIPTION
We attempted to match the health check output string with an additional colon.