### PR TITLE
🔒 Add cert-manager to cluster and secure Thanos endpoint

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/cert-issuer.yaml
+++ b/kubernetes/infrastructure-monitoring/templates/cert-issuer.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: {{ .Values.cert_slack_email }}
+    privateKeySecretRef:
+      name: letsencrypt
+    server: {{ .Values.letsencrypt_url }}
+    solvers: 
+      - dns01:
+          route53:
+            region: eu-west-2
+            hostedZoneID: {{ .Values.public_hosted_zone_id }}

--- a/kubernetes/infrastructure-monitoring/templates/ingress-nginx-secure.yaml
+++ b/kubernetes/infrastructure-monitoring/templates/ingress-nginx-secure.yaml
@@ -3,13 +3,19 @@ kind: Ingress
 metadata:
   name: {{ .Release.Name }}-ingress-nginx-secure
   annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
     nginx.ingress.kubernetes.io/auth-type: basic
     nginx.ingress.kubernetes.io/auth-secret: basic-auth
     nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - Prometheus'
 spec:
+  tls:
+  - hosts:
+    - thanos.{{ .Values.hosted_zone_public }}
+    secretName: thanos-ssl  
   rules:
-  - host: thanos-secure-{{ .Release.Namespace }}.{{ .Values.hosted_zone_public }}
+  - host: thanos.{{ .Values.hosted_zone_public }}
     http:
       paths:
         - path: /
@@ -19,4 +25,5 @@ spec:
               name: {{ .Release.Name }}-thanos-receiver
               port:
                 number: 10908
+
                 

--- a/kubernetes/infrastructure-monitoring/values.yaml
+++ b/kubernetes/infrastructure-monitoring/values.yaml
@@ -1,6 +1,7 @@
 environment: ""
 hosted_zone_private: ""
 hosted_zone_public: ""
+public_hosted_zone_id: ""
 debug: false
 configmap_reload:
   image: ""
@@ -39,3 +40,5 @@ snmpexporter:
 network_address:
   corsham: ""
   farnborough: ""
+cert_slack_email: ""
+letsencrypt_url: ""

--- a/scripts/deploy_kubernetes.sh
+++ b/scripts/deploy_kubernetes.sh
@@ -10,6 +10,9 @@ get_outputs() {
   corsham_network_address=`aws ssm get-parameter --with-decryption --name /codebuild/pttp-ci-ima-pipeline/corsham-network-address | jq -r .Parameter.Value`
   farnborough_network_address=`aws ssm get-parameter --with-decryption --name /codebuild/pttp-ci-ima-pipeline/farnborough-network-address | jq -r .Parameter.Value`
   cloudwatch_exporter_access_role_arns=`aws ssm get-parameter --with-decryption --name /codebuild/pttp-ci-ima-pipeline/production/cloudwatch_exporter_access_role_arns | jq -r .Parameter.Value`
+  cert_slack_email=`aws ssm get-parameter --with-decryption --name /codebuild/pttp-ci-ima-pipeline/cert-slack-email | jq -r .Parameter.Value`
+  letsencrypt_url=`aws ssm get-parameter --with-decryption --name /codebuild/pttp-ci-ima-pipeline/$ENV/letsencrypt-url | jq -r .Parameter.Value`
+  public_hosted_zone_id=`aws ssm get-parameter --with-decryption --name /codebuild/pttp-ci-ima-pipeline/$ENV/public_hosted_zone_id | jq -r .Parameter.Value`
 }
 
 install_dependent_helm_chart() {
@@ -115,7 +118,10 @@ smtpexporter.loadbalancer=$smtp_loadbalancer,\
 network_address.corsham=$corsham_network_address,\
 network_address.farnborough=$farnborough_network_address,\
 blackboxexporter.loadbalancer=$blackbox_loadbalancer,\
-snmpexporter.loadbalancer=$snmp_loadbalancer
+snmpexporter.loadbalancer=$snmp_loadbalancer,\
+cert_slack_email=$cert_slack_email,\
+letsencrypt_url=$letsencrypt_url,\
+public_hosted_zone_id=$public_hosted_zone_id
 }
 
 get_prometheus_endpoint() {

--- a/scripts/deploy_kubernetes.sh
+++ b/scripts/deploy_kubernetes.sh
@@ -15,6 +15,7 @@ get_outputs() {
 install_dependent_helm_chart() {
   helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
   helm repo add bitnami https://charts.bitnami.com/bitnami
+  helm repo add jetstack https://charts.jetstack.io
   helm repo update
 }
 
@@ -54,6 +55,15 @@ upgrade_auth_configmap(){
 deploy_ingress_nginx() {
   printf "\nInstalling/ upgrading NGINX Ingress chart\n\n"
   helm upgrade --install mojo-$ENV-ima-ingress-nginx ingress-nginx/ingress-nginx
+}
+
+deploy_cert_manager() {
+  printf "\nInstalling/ upgrading cert-manager chart\n\n"
+  helm upgrade --install mojo-$ENV-cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version v1.8.0 \
+  --set installCRDs=true
 }
 
 deploy_external_dns() {
@@ -100,6 +110,7 @@ azure.preprod.client_secret=$PREPROD_CLIENT_SECRET,\
 azure.preprod.tenant_id=$PREPROD_TENANT_ID,\
 hosted_zone_private=$HOSTED_ZONE_PRIVATE,\
 hosted_zone_public=$HOSTED_ZONE_PUBLIC,\
+hosted_zone_public_id=$HOSTED_ZONE_PUBLIC_ID,\
 smtpexporter.loadbalancer=$smtp_loadbalancer,\
 network_address.corsham=$corsham_network_address,\
 network_address.farnborough=$farnborough_network_address,\
@@ -124,6 +135,7 @@ main(){
     upgrade_auth_configmap
     deploy_ingress_nginx
     deploy_external_dns
+    deploy_cert_manager
     upgrade_ima_chart
     get_prometheus_endpoint
 


### PR DESCRIPTION
This PR adds cert-manager to the EKS cluster to manage SSL certificates.  The Thanos receiver endpoint is now secured other https.  This PR closes issue #78 