### PR TITLE
:stethoscope: Adding additional statistics for EC2 CPU Metric

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_default-metrics.tpl
+++ b/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_default-metrics.tpl
@@ -18,6 +18,9 @@ discovery:
       - name: CPUUtilization
         statistics:
           - Average
+          - Minimum
+          - Maximum
+          - Sum
         nilToZero: true
         period: 600
         length: 300


### PR DESCRIPTION
This PR will add the `Minimum`, `Maximum` and `Sum` options for the `EC2CPUUtilization` metric.  This will allow for enhanced monitoring and aid with troubleshooting [Issue #234](https://github.com/ministryofjustice/staff-infrastructure-monitoring-config/issues/234)