### PR TITLE
:stethoscope: Add ec2 metric statistics to production

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics.tpl
+++ b/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_production-metrics.tpl
@@ -17,7 +17,7 @@ discovery:
     length: 300
     metrics:
       - name: CPUUtilization
-        statistics: [Average]
+        statistics: [Average, Minimum, Maximum, Sum]
         nilToZero: true
       - name: StatusCheckFailed
         statistics: [Average]


### PR DESCRIPTION
This PR will add the Minimum, Maximum and Sum options for the EC2CPUUtilization metric in production. This will allow for enhanced monitoring and aid with troubleshooting [Issue #234](https://github.com/ministryofjustice/staff-infrastructure-monitoring-config/issues/234)