### PR TITLE
:sparkles: Add stakater/Reloader 

### DIFF
--- a/kubernetes/infrastructure-monitoring/templates/cloudwatch-exporter-deployment.yaml
+++ b/kubernetes/infrastructure-monitoring/templates/cloudwatch-exporter-deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    reloader.stakater.com/auto: "true"
   name: {{ .Release.Name }}-cloudwatch-exporter
   labels:
     app: cloudwatch-exporter

--- a/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_default-metrics.tpl
+++ b/kubernetes/infrastructure-monitoring/templates/cloudwatch-metrics/_default-metrics.tpl
@@ -22,7 +22,7 @@ discovery:
           - Maximum
           - Sum
         nilToZero: true
-        period: 600
+        period: 300
         length: 300
   - type: AWS/ECS
     regions:
@@ -34,7 +34,7 @@ discovery:
           - Minimum
           - Maximum
         nilToZero: true
-        period: 600
+        period: 300
         length: 300
       - name: MemoryUtilization
         statistics: 
@@ -42,7 +42,7 @@ discovery:
           - Minimum
           - Maximum
         nilToZero: true
-        period: 600
+        period: 300
         length: 300
   - type: AWS/RDS
     regions:
@@ -54,7 +54,7 @@ discovery:
           - Minimum
           - Maximum
         nilToZero: true
-        period: 600
+        period: 300
         length: 300
   - type: AWS/S3
     regions:
@@ -64,6 +64,6 @@ discovery:
         statistics:
           - Average
         nilToZero: true
-        period: 600
+        period: 300
         length: 300
 {{ end }}

--- a/scripts/deploy_kubernetes.sh
+++ b/scripts/deploy_kubernetes.sh
@@ -23,6 +23,7 @@ install_dependent_helm_chart() {
   helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
   helm repo add bitnami https://charts.bitnami.com/bitnami
   helm repo add jetstack https://charts.jetstack.io
+  helm repo add stakater https://stakater.github.io/stakater-charts
   helm repo update
 }
 
@@ -71,6 +72,11 @@ deploy_cert_manager() {
   --create-namespace \
   --version v1.8.0 \
   --set installCRDs=true
+}
+
+deploy_reloader() {
+  printf "\nInstalling/ upgrading cert-manager chart\n\n"
+  helm upgrade --install mojo-$ENV-reloader stakater/reloader 
 }
 
 deploy_external_dns() {
@@ -146,6 +152,7 @@ main(){
     create_kubernetes_namespace
     create_basic_auth
     upgrade_auth_configmap
+    deploy_reloader
     deploy_ingress_nginx
     deploy_external_dns
     deploy_cert_manager


### PR DESCRIPTION
This adds a [reloader pod](https://github.com/stakater/Reloader) to the cluster that watches for changes to configmaps, and reloads the associated deployment. This PR fixes #88 

Logs below of the reloader pod when a change is made to a configmap
![image](https://user-images.githubusercontent.com/68431297/168301369-41c871c7-041e-43ee-9a83-4973def00702.png)
